### PR TITLE
Fix include syntax in README

### DIFF
--- a/include/README
+++ b/include/README
@@ -4,7 +4,7 @@ This directory is intended for project header files.
 A header file is a file containing C declarations and macro definitions
 to be shared between several project source files. You request the use of a
 header file in your project source file (C, C++, etc) located in `src` folder
-by including it, with the C preprocessing directive `#include'.
+by including it, with the C preprocessing directive `#include`.
 
 ```src/main.c
 


### PR DESCRIPTION
## Summary
- correct `#include` directive example in include README

## Testing
- `grep -n "directive" -n include/README`


------
https://chatgpt.com/codex/tasks/task_e_68470cdab9a08330a9a72acfadb55d22