### PR TITLE
Fix duplicate include

### DIFF
--- a/src/time_mapper.cpp
+++ b/src/time_mapper.cpp
@@ -6,7 +6,6 @@
 #include "log.h"
 #include "wordposition.h"
 #include "time_mapper.h"
-#include "grid_layout.h"
 
 std::vector<uint16_t> get_leds_for_word(const char* word) {
   std::vector<uint16_t> result;


### PR DESCRIPTION
## Summary
- remove a duplicate `grid_layout.h` include from `time_mapper.cpp`

## Testing
- `g++ -c src/time_mapper.cpp -Iinclude -Isrc -std=c++17` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68470de59f7c83308f93cfcd52b8e676