### PR TITLE
Cursor/code review and analysis d4b7

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -3,8 +3,8 @@
 #define LOG_BUFFER_SIZE 150
 #pragma once
 
-#define FIRMWARE_VERSION "26.2.0-dev.2"
-#define UI_VERSION "26.2.0-dev.2"
+#define FIRMWARE_VERSION "26.2.0-dev.3"
+#define UI_VERSION "26.2.0-dev.3"
 
 #define DATA_PIN 4
 #define DEFAULT_BRIGHTNESS 5

--- a/src/config.h
+++ b/src/config.h
@@ -3,8 +3,8 @@
 #define LOG_BUFFER_SIZE 150
 #pragma once
 
-#define FIRMWARE_VERSION "26.1.5-rc.1"
-#define UI_VERSION "26.1.5-rc.1"
+#define FIRMWARE_VERSION "26.2.0-dev.2"
+#define UI_VERSION "26.2.0-dev.2"
 
 #define DATA_PIN 4
 #define DEFAULT_BRIGHTNESS 5

--- a/src/web_routes.h
+++ b/src/web_routes.h
@@ -505,6 +505,14 @@ void setupWebRoutes() {
     server.send(200, "application/json", json);
   });
 
+  // Force MQTT reconnection (clears abort state)
+  server.on("/api/mqtt/reconnect", HTTP_POST, []() {
+    if (!ensureUiAuth()) return;
+    logInfo("🔄 Force MQTT reconnect requested via web UI");
+    mqtt_force_reconnect();
+    server.send(200, "text/plain", "MQTT reconnection triggered");
+  });
+
   // MQTT connection test (does not save). Accepts form-encoded: host, port, user?, pass?
   server.on("/api/mqtt/test", HTTP_POST, []() {
     if (!ensureUiAuth()) return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **MQTT reconnection behavior**
> 
> - When max backoff is reached, switch to a slow-retry mode (every 5 minutes) instead of stopping retries; still clears on config change or manual trigger
> - Improved recovery logging: log successful reconnects, including when exiting slow-retry mode; reset reconnection state on success
> - New `mqtt_force_reconnect()` clears abort state and triggers immediate retry; exposed via `POST /api/mqtt/reconnect`
> 
> **Version bump**
> 
> - Update `FIRMWARE_VERSION` and `UI_VERSION` to `26.2.0-dev.3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab4e8ce969edbd1316ab32ab85bb1bc938941709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->